### PR TITLE
fix typo

### DIFF
--- a/src/trigger.c
+++ b/src/trigger.c
@@ -51,7 +51,7 @@ getTriggers(PGconn *c, int *n)
 	for (i = 0; i < *n; i++)
 	{
 		t[i].oid = strtoul(PQgetvalue(res, i, PQfnumber(res, "oid")), NULL, 10);
-		t[i].trgname = strdup(PQgetvalue(res, i, PQfnumber(res, "tgname")));
+		t[i].trgname = strdup(PQgetvalue(res, i, PQfnumber(res, "trgname")));
 		t[i].table.schemaname = strdup(PQgetvalue(res, i, PQfnumber(res, "nspname")));
 		t[i].table.objectname = strdup(PQgetvalue(res, i, PQfnumber(res, "relname")));
 		t[i].trgdef = strdup(PQgetvalue(res, i, PQfnumber(res, "trgdef")));


### PR DESCRIPTION
one user reported SIGSEGV:
<pre>
$ gdb --args ./pgquarrel -c test.ini
GNU gdb (GDB) Fedora 7.11.1-86.fc24
Reading symbols from ./pgquarrel...done.
(gdb) run
Starting program: /pgquarrel/pgquarrel -c test.ini
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
column number -1 is out of range 0..5

Program received signal SIGSEGV, Segmentation fault.
strlen () at ../sysdeps/x86_64/strlen.S:106
106		movdqu	(%rax), %xmm4
(gdb) backtrace 
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
#1  0x00007ffff766b06e in __GI___strdup (s=0x0) at strdup.c:41
#2  0x000000000042e644 in getTriggers (c=0x64c2e0, n=0x7fffffffdf14) at /pgquarrel/src/trigger.c:42
#3  0x000000000041ddaa in quarrelTriggers () at /pgquarrel/src/quarrel.c:1944
#4  0x00000000004212f5 in main (argc=3, argv=0x7fffffffe078) at /pgquarrel/src/quarrel.c:2898
</pre>