### PR TITLE
Compatibility with nix and google cloud sql

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,9 @@ else()
 	message(FATAL_ERROR "could not find PostgreSQL")
 endif(PostgreSQL_FOUND)
 
-set(LIBS ${LIBS} ${PostgreSQL_LIBRARY})
+find_package(OpenSSL REQUIRED)
+
+set(LIBS ${LIBS} ${PostgreSQL_LIBRARY} ${OPENSSL_LIBRARIES})
 # CMake does not include libpgport by default for Windows
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	set(LIBS ${LIBS} ${PostgreSQL_LIBRARY_DIRS}/libpgport.lib)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+with import <nixpkgs> { };
+
+pkgs.stdenv.mkDerivation rec {
+  name = "pgquarrel";
+  src = ./.;
+  buildInputs = [
+    cmake
+    pkgconfig
+    postgresql96
+    openssl
+  ];
+}

--- a/src/quarrel.c
+++ b/src/quarrel.c
@@ -3506,7 +3506,7 @@ int main(int argc, char *argv[])
 
 	quarrelForeignDataWrappers();
 	quarrelForeignServers();
-	quarrelUserMappings();
+	// quarrelUserMappings();
 
 	quarrelLanguages();
 	quarrelSchemas();


### PR DESCRIPTION
⚠️ NOT INTENDED FOR MERGING ⚠️

I tried to use this tool to migrate between two databases running on [google cloud sql](https://cloud.google.com/sql/docs/postgres/). The postgres version of google cloud sql is still in beta, but working nicely for me so far.

First of all, I used nix to build this binary. The default.nix file is included and rather simple. I had to change the CMakeLists.txt file and include the OpenSSL dependency. Without adding OPENSSL_LIBRARIES to LIBS, the linker wouldn't find the symbols from libssl.

Second, google cloud restricts access to the pg_user_mapping table, so I commented out that part.

    ERROR query failed: ERROR:  permission denied for relation pg_user_mapping

Could be nice to have this as an option in the [global] section of the config file.

Note that I only tested it with one simple table. There might be other things which are inaccessible in google cloud sdk.