### PR TITLE
Detect view definition changes

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -358,6 +358,12 @@ dumpAlterView(FILE *output, PQLView *a, PQLView *b)
 		}
 	}
 
+	if (strcmp(a->viewdef, b->viewdef) != 0)
+	{
+	  dumpDropView(output, a);
+	  dumpCreateView(output, b);
+	}
+
 	/* comment */
 	if (options.comment)
 	{

--- a/test/from-view.sql
+++ b/test/from-view.sql
@@ -3,3 +3,5 @@ CREATE VIEW same_view_1 AS SELECT prod_id, title, price FROM products WHERE comm
 CREATE VIEW same_view_2 AS SELECT orderdate, COUNT(*) AS total_day FROM orders GROUP BY orderdate;
 
 ALTER VIEW same_view_2 SET (security_barrier=on);
+
+CREATE VIEW same_view_3 AS SELECT orderdate, COUNT(*) AS total_day FROM orders GROUP BY orderdate;

--- a/test/to-view.sql
+++ b/test/to-view.sql
@@ -3,3 +3,5 @@ CREATE VIEW same_view_1 AS SELECT prod_id, title, price FROM products WHERE comm
 ALTER VIEW same_view_1 SET (security_barrier=on, check_option=cascaded);
 
 CREATE VIEW same_view_2 AS SELECT orderdate, COUNT(*) AS total_day FROM orders GROUP BY orderdate;
+
+CREATE VIEW same_view_3 AS SELECT orderdate, COUNT(*) AS totals_by_day FROM orders GROUP BY orderdate;


### PR DESCRIPTION
`pgquarrel` detects differences in function bodies, but differences in view definitions are ignored. This tiny fix makes it output `DROP/CREATE` commands for views whose definitions do not match. The definition is compared as text, similarly to how functions are compared.

Running tests on my machine turned out to be quite a challenge, but I got them to work eventually, and it looks like this new test case is processed correctly.