### PR TITLE
Handling escaped single quotes within comments.

### DIFF
--- a/src/aggregate.c
+++ b/src/aggregate.c
@@ -143,7 +143,10 @@ getAggregates(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			a[i].comment = NULL;
 		else
+		{
 			a[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			a[i].comment = escapeQuotes(a[i].comment);
+		}
 
 		a[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "aggowner")));
 

--- a/src/am.c
+++ b/src/am.c
@@ -67,7 +67,10 @@ getAccessMethods(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			a[i].comment = NULL;
 		else
+		{
 			a[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			a[i].comment = escapeQuotes(a[i].comment);
+		}
 
 		logDebug("access method \"%s\"", a[i].amname);
 	}

--- a/src/cast.c
+++ b/src/cast.c
@@ -179,7 +179,7 @@ dumpCreateCast(FILE *output, PQLCast *c)
 	if (options.comment && c->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON CAST (%s AS %s) IS '%s';",
+		fprintf(output, "COMMENT ON CAST (%s AS %s) IS $QUOT$%s$QUOT$;",
 				c->source,
 				c->target,
 				c->comment);
@@ -219,7 +219,7 @@ dumpAlterCast(FILE *output, PQLCast *a, PQLCast *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CAST (%s AS %s) IS '%s';",
+			fprintf(output, "COMMENT ON CAST (%s AS %s) IS $QUOT$%s$QUOT$;",
 					b->source,
 					b->target,
 					b->comment);

--- a/src/cast.c
+++ b/src/cast.c
@@ -108,7 +108,10 @@ getCasts(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		logDebug("cast \"%s\" as \"%s\" ; method: %c ; context: %c", d[i].source,
 				 d[i].target, d[i].method, d[i].context);

--- a/src/cast.c
+++ b/src/cast.c
@@ -179,7 +179,7 @@ dumpCreateCast(FILE *output, PQLCast *c)
 	if (options.comment && c->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON CAST (%s AS %s) IS $QUOT$%s$QUOT$;",
+		fprintf(output, "COMMENT ON CAST (%s AS %s) IS '%s';",
 				c->source,
 				c->target,
 				c->comment);
@@ -219,7 +219,7 @@ dumpAlterCast(FILE *output, PQLCast *a, PQLCast *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CAST (%s AS %s) IS $QUOT$%s$QUOT$;",
+			fprintf(output, "COMMENT ON CAST (%s AS %s) IS '%s';",
 					b->source,
 					b->target,
 					b->comment);

--- a/src/collation.c
+++ b/src/collation.c
@@ -113,7 +113,10 @@ getCollations(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		d[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "collowner")));
 

--- a/src/common.c
+++ b/src/common.c
@@ -732,3 +732,12 @@ escapeQuotes(char *str)
 {
 	return strReplace(str, "'", "''");
 }
+
+/*
+ * Replace escaped double-quote with double-quote.
+ */
+char*
+fixDoubleQuotes(char *str)
+{
+	return strReplace(str, "\\\"", "\"");
+}

--- a/src/common.c
+++ b/src/common.c
@@ -670,3 +670,65 @@ printOptions(stringList *sl)
 
 	return list;
 }
+
+/*
+ * Shamelessly copied from https://stackoverflow.com/questions/779875/what-is-the-function-to-replace-string-in-c#answer-779960
+ */
+// You must free the result if result is non-NULL.
+char*
+strReplace(char *orig, char *rep, char *with)
+{
+	char *result; // the return string
+	char *ins;    // the next insert point
+	char *tmp;    // varies
+	int len_rep;  // length of rep (the string to remove)
+	int len_with; // length of with (the string to replace rep with)
+	int len_front; // distance between rep and end of last rep
+	int count;    // number of replacements
+
+	// sanity checks and initialization
+	if (!orig || !rep)
+		return NULL;
+	len_rep = strlen(rep);
+	if (len_rep == 0)
+		return NULL; // empty rep causes infinite loop during count
+	if (!with)
+		with = "";
+	len_with = strlen(with);
+
+	// count the number of replacements needed
+	ins = orig;
+	for (count = 0; tmp = strstr(ins, rep); ++count)
+	{
+		ins = tmp + len_rep;
+	}
+
+	tmp = result = malloc(strlen(orig) + (len_with - len_rep) * count + 1);
+
+	if (!result)
+		return NULL;
+
+	// first time through the loop, all the variable are set correctly
+	// from here on,
+	//    tmp points to the end of the result string
+	//    ins points to the next occurrence of rep in orig
+	//    orig points to the remainder of orig after "end of rep"
+	while (count--) {
+		ins = strstr(orig, rep);
+		len_front = ins - orig;
+		tmp = strncpy(tmp, orig, len_front) + len_front;
+		tmp = strcpy(tmp, with) + len_with;
+		orig += len_front + len_rep; // move to next "end of rep"
+	}
+	strcpy(tmp, orig);
+	return result;
+}
+
+/*
+ * Replace any occurrence of single quote with two single quotes.
+ */
+char*
+escapeQuotes(char *str)
+{
+	return strReplace(str, "'", "''");
+}

--- a/src/common.h
+++ b/src/common.h
@@ -202,4 +202,6 @@ bool searchStringList(stringList *sl, const char *s);
 #endif
 void freeStringList(stringList *sl);
 
+char *escapeQuotes(char *str);
+
 #endif	/* COMMON_H */

--- a/src/common.h
+++ b/src/common.h
@@ -203,5 +203,6 @@ bool searchStringList(stringList *sl, const char *s);
 void freeStringList(stringList *sl);
 
 char *escapeQuotes(char *str);
+char *fixDoubleQuotes(char *str);
 
 #endif	/* COMMON_H */

--- a/src/conversion.c
+++ b/src/conversion.c
@@ -100,7 +100,10 @@ getConversions(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		d[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "conowner")));
 

--- a/src/domain.c
+++ b/src/domain.c
@@ -333,7 +333,7 @@ dumpCreateDomain(FILE *output, PQLDomain *d)
 	if (options.comment && d->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+		fprintf(output, "COMMENT ON DOMAIN %s.%s IS '%s';",
 				schema,
 				domname,
 				d->comment);
@@ -345,7 +345,7 @@ dumpCreateDomain(FILE *output, PQLDomain *d)
 		for (i = 0; i < d->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+			fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
 					d->seclabels[i].provider,
 					schema,
 					domname,
@@ -431,7 +431,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+			fprintf(output, "COMMENT ON DOMAIN %s.%s IS '%s';",
 					schema2,
 					domname2,
 					b->comment);
@@ -455,7 +455,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+				fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
 						b->seclabels[i].provider,
 						schema2,
 						domname2,
@@ -485,7 +485,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
 							b->seclabels[j].provider,
 							schema2,
 							domname2,
@@ -506,7 +506,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+						fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
 								b->seclabels[j].provider,
 								schema2,
 								domname2,
@@ -527,7 +527,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
 							b->seclabels[j].provider,
 							schema2,
 							domname2,

--- a/src/domain.c
+++ b/src/domain.c
@@ -92,7 +92,10 @@ getDomains(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		d[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "typowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "typacl")))

--- a/src/domain.c
+++ b/src/domain.c
@@ -333,7 +333,7 @@ dumpCreateDomain(FILE *output, PQLDomain *d)
 	if (options.comment && d->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON DOMAIN %s.%s IS '%s';",
+		fprintf(output, "COMMENT ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 				schema,
 				domname,
 				d->comment);
@@ -345,7 +345,7 @@ dumpCreateDomain(FILE *output, PQLDomain *d)
 		for (i = 0; i < d->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
+			fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 					d->seclabels[i].provider,
 					schema,
 					domname,
@@ -431,7 +431,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON DOMAIN %s.%s IS '%s';",
+			fprintf(output, "COMMENT ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 					schema2,
 					domname2,
 					b->comment);
@@ -455,7 +455,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
+				fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 						b->seclabels[i].provider,
 						schema2,
 						domname2,
@@ -485,7 +485,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2,
 							domname2,
@@ -506,7 +506,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
+						fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 								b->seclabels[j].provider,
 								schema2,
 								domname2,
@@ -527,7 +527,7 @@ dumpAlterDomain(FILE *output, PQLDomain *a, PQLDomain *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON DOMAIN %s.%s IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2,
 							domname2,

--- a/src/eventtrigger.c
+++ b/src/eventtrigger.c
@@ -69,7 +69,10 @@ getEventTriggers(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			e[i].comment = NULL;
 		else
+		{
 			e[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			e[i].comment = escapeQuotes(e[i].comment);
+		}
 
 		e[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "evtowner")));
 

--- a/src/extension.c
+++ b/src/extension.c
@@ -73,7 +73,10 @@ getExtensions(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			e[i].comment = NULL;
 		else
+		{
 			e[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			e[i].comment = escapeQuotes(e[i].comment);
+		}
 
 		logDebug("extension \"%s\"", e[i].extensionname);
 	}

--- a/src/fdw.c
+++ b/src/fdw.c
@@ -101,7 +101,10 @@ getForeignDataWrappers(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			f[i].comment = NULL;
 		else
+		{
 			f[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			f[i].comment = escapeQuotes(f[i].comment);
+		}
 
 		logDebug("foreign data wrapper \"%s\"", f[i].fdwname);
 	}

--- a/src/function.c
+++ b/src/function.c
@@ -342,7 +342,7 @@ dumpCreateFunction(FILE *output, PQLFunction *f, bool orreplace)
 	if (options.comment && f->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS '%s';",
+		fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 				schema,
 				funcname,
 				f->iarguments,
@@ -357,7 +357,7 @@ dumpCreateFunction(FILE *output, PQLFunction *f, bool orreplace)
 		for (i = 0; i < f->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
+			fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 					f->seclabels[i].provider,
 					schema,
 					funcname,
@@ -667,7 +667,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS '%s';",
+			fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 					schema2, funcname2, b->iarguments, b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)
@@ -688,7 +688,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
+				fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 						b->seclabels[i].provider,
 						schema2, funcname2, b->iarguments, b->seclabels[i].label);
 			}
@@ -715,7 +715,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2, funcname2, b->iarguments, b->seclabels[j].label);
 					j++;
@@ -733,7 +733,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
+						fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 								b->seclabels[j].provider,
 								schema2, funcname2, b->iarguments, b->seclabels[j].label);
 					}
@@ -751,7 +751,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2, funcname2, b->iarguments, b->seclabels[j].label);
 					j++;

--- a/src/function.c
+++ b/src/function.c
@@ -342,7 +342,7 @@ dumpCreateFunction(FILE *output, PQLFunction *f, bool orreplace)
 	if (options.comment && f->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+		fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS '%s';",
 				schema,
 				funcname,
 				f->iarguments,
@@ -357,7 +357,7 @@ dumpCreateFunction(FILE *output, PQLFunction *f, bool orreplace)
 		for (i = 0; i < f->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+			fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
 					f->seclabels[i].provider,
 					schema,
 					funcname,
@@ -667,7 +667,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+			fprintf(output, "COMMENT ON FUNCTION %s.%s(%s) IS '%s';",
 					schema2, funcname2, b->iarguments, b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)
@@ -688,7 +688,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+				fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
 						b->seclabels[i].provider,
 						schema2, funcname2, b->iarguments, b->seclabels[i].label);
 			}
@@ -715,7 +715,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
 							b->seclabels[j].provider,
 							schema2, funcname2, b->iarguments, b->seclabels[j].label);
 					j++;
@@ -733,7 +733,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+						fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
 								b->seclabels[j].provider,
 								schema2, funcname2, b->iarguments, b->seclabels[j].label);
 					}
@@ -751,7 +751,7 @@ dumpAlterFunction(FILE *output, PQLFunction *a, PQLFunction *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON FUNCTION %s.%s(%s) IS '%s';",
 							b->seclabels[j].provider,
 							schema2, funcname2, b->iarguments, b->seclabels[j].label);
 					j++;

--- a/src/function.c
+++ b/src/function.c
@@ -103,7 +103,10 @@ getFunctions(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			f[i].comment = NULL;
 		else
+		{
 			f[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			f[i].comment = escapeQuotes(f[i].comment);
+		}
 
 		f[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "proowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "proacl")))

--- a/src/index.c
+++ b/src/index.c
@@ -71,7 +71,10 @@ getIndexes(PGconn *c, int *n)
 		if (PQgetisnull(res, k, PQfnumber(res, "description")))
 			i[k].comment = NULL;
 		else
+		{
 			i[k].comment = strdup(PQgetvalue(res, k, PQfnumber(res, "description")));
+			i[k].comment = escapeQuotes(i[k].comment);
+		}
 
 		logDebug("index \"%s\".\"%s\"", i[k].obj.schemaname, i[k].obj.objectname);
 	}

--- a/src/language.c
+++ b/src/language.c
@@ -73,7 +73,10 @@ getLanguages(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			l[i].comment = NULL;
 		else
+		{
 			l[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			l[i].comment = escapeQuotes(l[i].comment);
+		}
 
 		l[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "lanowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "lanacl")))

--- a/src/matview.c
+++ b/src/matview.c
@@ -99,7 +99,10 @@ getMaterializedViews(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			v[i].comment = NULL;
 		else
+		{
 			v[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			v[i].comment = escapeQuotes(v[i].comment);
+		}
 
 		v[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "relowner")));
 

--- a/src/operator.c
+++ b/src/operator.c
@@ -130,7 +130,10 @@ getOperators(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			o[i].comment = NULL;
 		else
+		{
 			o[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			o[i].comment = escapeQuotes(o[i].comment);
+		}
 
 		o[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "oprowner")));
 
@@ -233,7 +236,10 @@ getOperatorClasses(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		d[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "opcowner")));
 	}
@@ -308,7 +314,10 @@ getOperatorFamilies(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			f[i].comment = NULL;
 		else
+		{
 			f[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			f[i].comment = escapeQuotes(f[i].comment);
+		}
 
 		f[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "opfowner")));
 	}

--- a/src/policy.c
+++ b/src/policy.c
@@ -75,7 +75,10 @@ getPolicies(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			p[i].comment = NULL;
 		else
+		{
 			p[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			p[i].comment = escapeQuotes(p[i].comment);
+		}
 
 		logDebug("policy \"%s\" on \"%s\".\"%s\"", p[i].polname, p[i].table.schemaname,
 				 p[i].table.objectname);

--- a/src/privileges.c
+++ b/src/privileges.c
@@ -170,6 +170,18 @@ splitACLItem(char *a)
 
 	ptr = a;
 
+	/* If first character is double-quote then we probably deal with something like below:
+	 * "\"to-quoted-role\"=U/quarrel"
+	 * In such case leading and trailing `"` must be stripped
+	 * and escaped quotes must be replaced with quotes
+	 */
+	if (ptr[0] == '"' && ptr[strlen(ptr)-1] == '"')
+	    ptr = fixDoubleQuotes(ptr);
+	if (ptr[0] == '"')
+		ptr++;
+	if (ptr[strlen(ptr)-1] == '"')
+		ptr[strlen(ptr)-1]=0;
+
 	/* grantee */
 	nextptr = strchr(ptr, '=');
 	if (nextptr)

--- a/src/rule.c
+++ b/src/rule.c
@@ -59,7 +59,10 @@ getRules(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			r[i].comment = NULL;
 		else
+		{
 			r[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			r[i].comment = escapeQuotes(r[i].comment);
+		}
 
 		logDebug("rule \"%s\" on \"%s\".\"%s\"", r[i].rulename, r[i].table.schemaname,
 				 r[i].table.objectname);

--- a/src/schema.c
+++ b/src/schema.c
@@ -67,7 +67,10 @@ getSchemas(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			s[i].comment = NULL;
 		else
+		{
 			s[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			s[i].comment = escapeQuotes(s[i].comment);
+		}
 
 		s[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "nspowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "nspacl")))

--- a/src/sequence.c
+++ b/src/sequence.c
@@ -71,7 +71,10 @@ getSequences(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			s[i].comment = NULL;
 		else
+		{
 			s[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			s[i].comment = escapeQuotes(s[i].comment);
+		}
 
 		s[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "relowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "relacl")))

--- a/src/sequence.c
+++ b/src/sequence.c
@@ -383,7 +383,7 @@ dumpCreateSequence(FILE *output, PQLSequence *s)
 	if (options.comment && s->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;", schema, seqname,
+		fprintf(output, "COMMENT ON SEQUENCE %s.%s IS '%s';", schema, seqname,
 				s->comment);
 	}
 
@@ -395,7 +395,7 @@ dumpCreateSequence(FILE *output, PQLSequence *s)
 		for (i = 0; i < s->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
+			fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
 					s->seclabels[i].provider,
 					schema,
 					seqname,
@@ -528,7 +528,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;", schema2, seqname2,
+			fprintf(output, "COMMENT ON SEQUENCE %s.%s IS '%s';", schema2, seqname2,
 					b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)
@@ -548,7 +548,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
+				fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
 						b->seclabels[i].provider,
 						schema2,
 						seqname2,
@@ -578,7 +578,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
 							b->seclabels[j].provider,
 							schema2,
 							seqname2,
@@ -599,7 +599,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
+						fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
 								b->seclabels[j].provider,
 								schema2,
 								seqname2,
@@ -620,7 +620,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
 							b->seclabels[j].provider,
 							schema2,
 							seqname2,

--- a/src/sequence.c
+++ b/src/sequence.c
@@ -383,7 +383,7 @@ dumpCreateSequence(FILE *output, PQLSequence *s)
 	if (options.comment && s->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON SEQUENCE %s.%s IS '%s';", schema, seqname,
+		fprintf(output, "COMMENT ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;", schema, seqname,
 				s->comment);
 	}
 
@@ -395,7 +395,7 @@ dumpCreateSequence(FILE *output, PQLSequence *s)
 		for (i = 0; i < s->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
+			fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
 					s->seclabels[i].provider,
 					schema,
 					seqname,
@@ -528,7 +528,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON SEQUENCE %s.%s IS '%s';", schema2, seqname2,
+			fprintf(output, "COMMENT ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;", schema2, seqname2,
 					b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)
@@ -548,7 +548,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
+				fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
 						b->seclabels[i].provider,
 						schema2,
 						seqname2,
@@ -578,7 +578,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2,
 							seqname2,
@@ -599,7 +599,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
+						fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
 								b->seclabels[j].provider,
 								schema2,
 								seqname2,
@@ -620,7 +620,7 @@ dumpAlterSequence(FILE *output, PQLSequence *a, PQLSequence *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON SEQUENCE %s.%s IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2,
 							seqname2,

--- a/src/server.c
+++ b/src/server.c
@@ -86,7 +86,10 @@ getForeignServers(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			s[i].comment = NULL;
 		else
+		{
 			s[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			s[i].comment = escapeQuotes(s[i].comment);
+		}
 
 		logDebug("foreign server \"%s\"", s[i].servername);
 	}

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -114,7 +114,7 @@ dumpCreateStatistics(FILE *output, PQLStatistics *s)
 	if (options.comment && s->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON STATISTICS %s.%s IS $QUOT$%s$QUOT$;", schema, stxname,
+		fprintf(output, "COMMENT ON STATISTICS %s.%s IS '%s';", schema, stxname,
 				s->comment);
 	}
 
@@ -159,7 +159,7 @@ dumpAlterStatistics(FILE *output, PQLStatistics *a, PQLStatistics *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON STATISTICS %s.%s IS $QUOT$%s$QUOT$;", schema2, stxname2,
+			fprintf(output, "COMMENT ON STATISTICS %s.%s IS '%s';", schema2, stxname2,
 					b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -69,7 +69,10 @@ getStatistics(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			s[i].comment = NULL;
 		else
+		{
 			s[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			s[i].comment = escapeQuotes(s[i].comment);
+		}
 		s[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "stxowner")));
 
 		logDebug("statistics \"%s\".\"%s\"", s[i].obj.schemaname, s[i].obj.objectname);

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -114,7 +114,7 @@ dumpCreateStatistics(FILE *output, PQLStatistics *s)
 	if (options.comment && s->comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON STATISTICS %s.%s IS '%s';", schema, stxname,
+		fprintf(output, "COMMENT ON STATISTICS %s.%s IS $QUOT$%s$QUOT$;", schema, stxname,
 				s->comment);
 	}
 
@@ -159,7 +159,7 @@ dumpAlterStatistics(FILE *output, PQLStatistics *a, PQLStatistics *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON STATISTICS %s.%s IS '%s';", schema2, stxname2,
+			fprintf(output, "COMMENT ON STATISTICS %s.%s IS $QUOT$%s$QUOT$;", schema2, stxname2,
 					b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)

--- a/src/table.c
+++ b/src/table.c
@@ -1140,7 +1140,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 		if (t->comment != NULL)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON TABLE %s.%s IS '%s';", schema, tabname, t->comment);
+			fprintf(output, "COMMENT ON TABLE %s.%s IS $QUOT$%s$QUOT$;", schema, tabname, t->comment);
 		}
 
 		/* columns */
@@ -1151,7 +1151,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				char	*attname = formatObjectIdentifier(t->attributes[i].attname);
 
 				fprintf(output, "\n\n");
-				fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS '%s';", schema, tabname, attname,
+				fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;", schema, tabname, attname,
 						t->attributes[i].comment);
 
 				free(attname);
@@ -1164,7 +1164,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 			char	*pkname = formatObjectIdentifier(t->pk.conname);
 
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", pkname, schema,
+			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", pkname, schema,
 					tabname, t->pk.comment);
 
 			free(pkname);
@@ -1178,7 +1178,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				char	*fkname = formatObjectIdentifier(t->fk[i].conname);
 
 				fprintf(output, "\n\n");
-				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", fkname, schema,
+				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", fkname, schema,
 						tabname, t->fk[i].comment);
 
 				free(fkname);
@@ -1193,7 +1193,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				char	*ckname = formatObjectIdentifier(t->check[i].conname);
 
 				fprintf(output, "\n\n");
-				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", ckname, schema,
+				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", ckname, schema,
 						tabname, t->check[i].comment);
 
 				free(ckname);
@@ -1222,7 +1222,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 		for (i = 0; i < t->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
+			fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
 					t->seclabels[i].provider,
 					schema,
 					tabname,
@@ -1240,7 +1240,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				for (j = 0; j < t->attributes[i].nseclabels; j++)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
 							t->attributes[i].seclabels[j].provider,
 							schema,
 							tabname,
@@ -1326,7 +1326,7 @@ dumpAddColumn(FILE *output, PQLTable *t, int i)
 	if (options.comment && t->attributes[i].comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS '%s';", schema, tabname, attname,
+		fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;", schema, tabname, attname,
 				t->attributes[i].comment);
 	}
 
@@ -1338,7 +1338,7 @@ dumpAddColumn(FILE *output, PQLTable *t, int i)
 		for (j = 0; j < t->attributes[i].nseclabels; j++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
+			fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
 					t->attributes[i].seclabels[j].provider,
 					schema,
 					tabname,
@@ -1445,7 +1445,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 				 strcmp(a->attributes[i].comment, b->attributes[j].comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS '%s';", schema2, tabname2,
+			fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;", schema2, tabname2,
 					attname2, b->attributes[j].comment);
 		}
 		else if (a->attributes[i].comment != NULL && b->attributes[j].comment == NULL)
@@ -1466,7 +1466,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 			for (k = 0; k < b->attributes[j].nseclabels; k++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
+				fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
 						b->attributes[j].seclabels[k].provider,
 						schema2,
 						tabname2,
@@ -1500,7 +1500,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 				if (k == a->attributes[i].nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
 							b->attributes[j].seclabels[l].provider,
 							schema2,
 							tabname2,
@@ -1525,7 +1525,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 							   b->attributes[j].seclabels[l].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
+						fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
 								b->attributes[j].seclabels[l].provider,
 								schema2,
 								tabname2,
@@ -1550,7 +1550,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 								b->attributes[j].seclabels[l].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
 							b->attributes[j].seclabels[l].provider,
 							schema2,
 							tabname2,
@@ -1735,7 +1735,7 @@ dumpAddPK(FILE *output, PQLTable *t)
 			char	*pkname = formatObjectIdentifier(t->pk.conname);
 
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", pkname, schema,
+			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", pkname, schema,
 					tabname, t->pk.comment);
 
 			free(pkname);
@@ -1779,7 +1779,7 @@ dumpAddFK(FILE *output, PQLTable *t, int i)
 			char	*fkname = formatObjectIdentifier(t->fk[i].conname);
 
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", fkname, schema,
+			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", fkname, schema,
 					tabname, t->fk[i].comment);
 
 			free(fkname);
@@ -2224,7 +2224,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON TABLE %s.%s IS '%s';", schema2, tabname2,
+			fprintf(output, "COMMENT ON TABLE %s.%s IS $QUOT$%s$QUOT$;", schema2, tabname2,
 					b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)
@@ -2242,7 +2242,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
+				fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
 						b->seclabels[i].provider,
 						schema2,
 						tabname2,
@@ -2268,7 +2268,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2,
 							tabname2,
@@ -2289,7 +2289,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
+						fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
 								b->seclabels[j].provider,
 								schema2,
 								tabname2,
@@ -2310,7 +2310,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
+					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
 							b->seclabels[j].provider,
 							schema2,
 							tabname2,

--- a/src/table.c
+++ b/src/table.c
@@ -149,7 +149,10 @@ getTables(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		t[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "relowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "relacl")))
@@ -333,8 +336,11 @@ getCheckConstraints(PGconn *c, PQLTable *t, int n)
 			if (PQgetisnull(res, j, PQfnumber(res, "description")))
 				t[i].check[j].comment = NULL;
 			else
+			{
 				t[i].check[j].comment = strdup(PQgetvalue(res, j, PQfnumber(res,
 											   "description")));
+				t[i].check[j].comment = escapeQuotes(t[i].check[j].comment);
+			}
 		}
 
 		PQclear(res);
@@ -394,7 +400,10 @@ getFKConstraints(PGconn *c, PQLTable *t, int n)
 			if (PQgetisnull(res, j, PQfnumber(res, "description")))
 				t[i].fk[j].comment = NULL;
 			else
+			{
 				t[i].fk[j].comment = strdup(PQgetvalue(res, j, PQfnumber(res, "description")));
+				t[i].fk[j].comment = escapeQuotes(t[i].fk[j].comment);
+			}
 		}
 
 		PQclear(res);
@@ -447,7 +456,10 @@ getPKConstraints(PGconn *c, PQLTable *t, int n)
 			if (PQgetisnull(res, 0, PQfnumber(res, "description")))
 				t[i].pk.comment = NULL;
 			else
+			{
 				t[i].pk.comment = strdup(PQgetvalue(res, 0, PQfnumber(res, "description")));
+				t[i].pk.comment = escapeQuotes(t[i].pk.comment);
+			}
 		}
 		/* XXX cannot happen */
 		else if (PQntuples(res) > 1)
@@ -595,8 +607,11 @@ getTableAttributes(PGconn *c, PQLTable *t)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t->attributes[i].comment = NULL;
 		else
+		{
 			t->attributes[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res,
 											  "description")));
+			t->attributes[i].comment = escapeQuotes(t->attributes[i].comment);
+		}
 
 		/*
 		 * Security labels are not assigned here (see getTableSecurityLabels),

--- a/src/table.c
+++ b/src/table.c
@@ -1140,7 +1140,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 		if (t->comment != NULL)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON TABLE %s.%s IS $QUOT$%s$QUOT$;", schema, tabname, t->comment);
+			fprintf(output, "COMMENT ON TABLE %s.%s IS '%s';", schema, tabname, t->comment);
 		}
 
 		/* columns */
@@ -1151,7 +1151,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				char	*attname = formatObjectIdentifier(t->attributes[i].attname);
 
 				fprintf(output, "\n\n");
-				fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;", schema, tabname, attname,
+				fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS '%s';", schema, tabname, attname,
 						t->attributes[i].comment);
 
 				free(attname);
@@ -1164,7 +1164,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 			char	*pkname = formatObjectIdentifier(t->pk.conname);
 
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", pkname, schema,
+			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", pkname, schema,
 					tabname, t->pk.comment);
 
 			free(pkname);
@@ -1178,7 +1178,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				char	*fkname = formatObjectIdentifier(t->fk[i].conname);
 
 				fprintf(output, "\n\n");
-				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", fkname, schema,
+				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", fkname, schema,
 						tabname, t->fk[i].comment);
 
 				free(fkname);
@@ -1193,7 +1193,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				char	*ckname = formatObjectIdentifier(t->check[i].conname);
 
 				fprintf(output, "\n\n");
-				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", ckname, schema,
+				fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", ckname, schema,
 						tabname, t->check[i].comment);
 
 				free(ckname);
@@ -1222,7 +1222,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 		for (i = 0; i < t->nseclabels; i++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
+			fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
 					t->seclabels[i].provider,
 					schema,
 					tabname,
@@ -1240,7 +1240,7 @@ dumpCreateTable(FILE *output, FILE *output2, PQLTable *t)
 				for (j = 0; j < t->attributes[i].nseclabels; j++)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
 							t->attributes[i].seclabels[j].provider,
 							schema,
 							tabname,
@@ -1326,7 +1326,7 @@ dumpAddColumn(FILE *output, PQLTable *t, int i)
 	if (options.comment && t->attributes[i].comment != NULL)
 	{
 		fprintf(output, "\n\n");
-		fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;", schema, tabname, attname,
+		fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS '%s';", schema, tabname, attname,
 				t->attributes[i].comment);
 	}
 
@@ -1338,7 +1338,7 @@ dumpAddColumn(FILE *output, PQLTable *t, int i)
 		for (j = 0; j < t->attributes[i].nseclabels; j++)
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
+			fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
 					t->attributes[i].seclabels[j].provider,
 					schema,
 					tabname,
@@ -1445,7 +1445,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 				 strcmp(a->attributes[i].comment, b->attributes[j].comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;", schema2, tabname2,
+			fprintf(output, "COMMENT ON COLUMN %s.%s.%s IS '%s';", schema2, tabname2,
 					attname2, b->attributes[j].comment);
 		}
 		else if (a->attributes[i].comment != NULL && b->attributes[j].comment == NULL)
@@ -1466,7 +1466,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 			for (k = 0; k < b->attributes[j].nseclabels; k++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
+				fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
 						b->attributes[j].seclabels[k].provider,
 						schema2,
 						tabname2,
@@ -1500,7 +1500,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 				if (k == a->attributes[i].nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
 							b->attributes[j].seclabels[l].provider,
 							schema2,
 							tabname2,
@@ -1525,7 +1525,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 							   b->attributes[j].seclabels[l].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
+						fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
 								b->attributes[j].seclabels[l].provider,
 								schema2,
 								tabname2,
@@ -1550,7 +1550,7 @@ dumpAlterColumn(FILE *output, PQLTable *a, int i, PQLTable *b, int j)
 								b->attributes[j].seclabels[l].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON COLUMN %s.%s.%s IS '%s';",
 							b->attributes[j].seclabels[l].provider,
 							schema2,
 							tabname2,
@@ -1735,7 +1735,7 @@ dumpAddPK(FILE *output, PQLTable *t)
 			char	*pkname = formatObjectIdentifier(t->pk.conname);
 
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", pkname, schema,
+			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", pkname, schema,
 					tabname, t->pk.comment);
 
 			free(pkname);
@@ -1779,7 +1779,7 @@ dumpAddFK(FILE *output, PQLTable *t, int i)
 			char	*fkname = formatObjectIdentifier(t->fk[i].conname);
 
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS $QUOT$%s$QUOT$;", fkname, schema,
+			fprintf(output, "COMMENT ON CONSTRAINT %s ON %s.%s IS '%s';", fkname, schema,
 					tabname, t->fk[i].comment);
 
 			free(fkname);
@@ -2224,7 +2224,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 				 strcmp(a->comment, b->comment) != 0))
 		{
 			fprintf(output, "\n\n");
-			fprintf(output, "COMMENT ON TABLE %s.%s IS $QUOT$%s$QUOT$;", schema2, tabname2,
+			fprintf(output, "COMMENT ON TABLE %s.%s IS '%s';", schema2, tabname2,
 					b->comment);
 		}
 		else if (a->comment != NULL && b->comment == NULL)
@@ -2242,7 +2242,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 			for (i = 0; i < b->nseclabels; i++)
 			{
 				fprintf(output, "\n\n");
-				fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
+				fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
 						b->seclabels[i].provider,
 						schema2,
 						tabname2,
@@ -2268,7 +2268,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 				if (i == a->nseclabels)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
 							b->seclabels[j].provider,
 							schema2,
 							tabname2,
@@ -2289,7 +2289,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 					if (strcmp(a->seclabels[i].label, b->seclabels[j].label) != 0)
 					{
 						fprintf(output, "\n\n");
-						fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
+						fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
 								b->seclabels[j].provider,
 								schema2,
 								tabname2,
@@ -2310,7 +2310,7 @@ dumpAlterTable(FILE *output, PQLTable *a, PQLTable *b)
 				else if (strcmp(a->seclabels[i].provider, b->seclabels[j].provider) > 0)
 				{
 					fprintf(output, "\n\n");
-					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS $QUOT$%s$QUOT$;",
+					fprintf(output, "SECURITY LABEL FOR %s ON TABLE %s.%s IS '%s';",
 							b->seclabels[j].provider,
 							schema2,
 							tabname2,

--- a/src/textsearch.c
+++ b/src/textsearch.c
@@ -105,7 +105,10 @@ getTextSearchConfigs(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		d[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "cfgowner")));
 
@@ -177,7 +180,10 @@ getTextSearchDicts(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			d[i].comment = NULL;
 		else
+		{
 			d[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			d[i].comment = escapeQuotes(d[i].comment);
+		}
 
 		d[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "dictowner")));
 
@@ -252,7 +258,10 @@ getTextSearchParsers(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			p[i].comment = NULL;
 		else
+		{
 			p[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			p[i].comment = escapeQuotes(p[i].comment);
+		}
 
 		logDebug("text search parser \"%s\".\"%s\"", p[i].obj.schemaname,
 				 p[i].obj.objectname);
@@ -321,7 +330,10 @@ getTextSearchTemplates(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		logDebug("text search template \"%s\".\"%s\"", t[i].obj.schemaname,
 				 t[i].obj.objectname);

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -58,7 +58,10 @@ getTriggers(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		logDebug("trigger \"%s\" on \"%s\".\"%s\"", t[i].trgname, t[i].table.schemaname,
 				 t[i].table.objectname);

--- a/src/type.c
+++ b/src/type.c
@@ -102,7 +102,10 @@ getBaseTypes(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		t[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "typowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "typacl")))
@@ -314,7 +317,10 @@ getCompositeTypes(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		t[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "typowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "typacl")))
@@ -510,7 +516,10 @@ getEnumTypes(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		t[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "typowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "typacl")))
@@ -650,7 +659,10 @@ getRangeTypes(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			t[i].comment = NULL;
 		else
+		{
 			t[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			t[i].comment = escapeQuotes(t[i].comment);
+		}
 
 		t[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "typowner")));
 		if (PQgetisnull(res, i, PQfnumber(res, "typacl")))

--- a/src/type.c
+++ b/src/type.c
@@ -459,9 +459,10 @@ getEnumTypeLabels(PGconn *c, PQLEnumType *t)
 	logDebug("number of labels on enum type \"%s\".\"%s\": %d", t->obj.schemaname,
 			 t->obj.objectname, t->nlabels);
 
-	for (i = 0; i < t->nlabels; i++)
+	for (i = 0; i < t->nlabels; i++) {
 		t->labels[i] = strdup(PQgetvalue(res, i, PQfnumber(res, "enumlabel")));
 		t->labels[i] = escapeQuotes(t->labels[i]);
+	}
 
 	PQclear(res);
 }

--- a/src/type.c
+++ b/src/type.c
@@ -461,6 +461,7 @@ getEnumTypeLabels(PGconn *c, PQLEnumType *t)
 
 	for (i = 0; i < t->nlabels; i++)
 		t->labels[i] = strdup(PQgetvalue(res, i, PQfnumber(res, "enumlabel")));
+		t->labels[i] = escapeQuotes(t->labels[i]);
 
 	PQclear(res);
 }
@@ -592,6 +593,8 @@ getEnumTypeSecurityLabels(PGconn *c, PQLEnumType *t)
 		t->seclabels[i].provider = strdup(PQgetvalue(res, i, PQfnumber(res,
 										  "provider")));
 		t->seclabels[i].label = strdup(PQgetvalue(res, i, PQfnumber(res, "label")));
+		t->seclabels[i].label = escapeQuotes(t->seclabels[i].label);
+
 	}
 
 	PQclear(res);

--- a/src/view.c
+++ b/src/view.c
@@ -90,7 +90,10 @@ getViews(PGconn *c, int *n)
 		if (PQgetisnull(res, i, PQfnumber(res, "description")))
 			v[i].comment = NULL;
 		else
+		{
 			v[i].comment = strdup(PQgetvalue(res, i, PQfnumber(res, "description")));
+			v[i].comment = escapeQuotes(v[i].comment);
+		}
 
 		v[i].owner = strdup(PQgetvalue(res, i, PQfnumber(res, "relowner")));
 

--- a/test/from-enum-type.sql
+++ b/test/from-enum-type.sql
@@ -1,0 +1,12 @@
+/* TODO: diff between enum labels does not work */
+/* Uncomment below to see the test failing */
+/*
+CREATE TYPE public.feature_type AS ENUM (
+        'val ''01''',
+        'val ''02''',
+        'val ''03''',
+        'val ''04''',
+        'val ''05''',
+        'val ''06'''
+);
+*/

--- a/test/from-schema.sql
+++ b/test/from-schema.sql
@@ -3,3 +3,6 @@ CREATE SCHEMA same_schema_1;
 
 GRANT ALL PRIVILEGES ON SCHEMA same_schema_1 TO same_role_1;
 GRANT USAGE ON SCHEMA same_schema_1 TO same_role_2;
+
+CREATE ROLE "from-quoted-role";
+GRANT USAGE ON SCHEMA from_schema_1 TO "from-quoted-role";

--- a/test/test-server1.sql
+++ b/test/test-server1.sql
@@ -52,4 +52,6 @@ CREATE EXTENSION file_fdw;
 
 \i from-statistics.sql
 
+\i from-enum-type.sql
+
 --\i from-user-mapping.sql

--- a/test/test-server2.sql
+++ b/test/test-server2.sql
@@ -52,4 +52,6 @@ CREATE EXTENSION file_fdw;
 
 \i to-statistics.sql
 
+\i to-enum-type.sql
+
 --\i to-user-mapping.sql

--- a/test/to-cast.sql
+++ b/test/to-cast.sql
@@ -2,8 +2,4 @@ CREATE CAST (json AS character varying) WITHOUT FUNCTION;
 
 CREATE CAST (json AS text) WITHOUT FUNCTION AS IMPLICIT;
 
-CREATE CAST (float AS text) WITHOUT FUNCTION AS IMPLICIT;
-
 COMMENT ON CAST (json AS text) IS 'this is comment for cast json -> text';
-
-COMMENT ON CAST (float AS text) IS 'this is comment for cast float -> text';

--- a/test/to-cast.sql
+++ b/test/to-cast.sql
@@ -2,4 +2,8 @@ CREATE CAST (json AS character varying) WITHOUT FUNCTION;
 
 CREATE CAST (json AS text) WITHOUT FUNCTION AS IMPLICIT;
 
+CREATE CAST (float AS text) WITHOUT FUNCTION AS IMPLICIT;
+
 COMMENT ON CAST (json AS text) IS 'this is comment for cast json -> text';
+
+COMMENT ON CAST (float AS text) IS 'this is comment for cast float -> text';

--- a/test/to-domain.sql
+++ b/test/to-domain.sql
@@ -15,6 +15,8 @@ CREATE DOMAIN same_domain_3 AS text;
 
 COMMENT ON DOMAIN same_domain_2 IS 'this is comment for same_domain_2';
 
+COMMENT ON DOMAIN same_domain_3 IS 'this is comment for same_domain_3 with ''';
+
 GRANT USAGE ON DOMAIN to_domain_1 TO same_role_1, same_role_2, same_role_3;
 GRANT ALL PRIVILEGES ON DOMAIN same_domain_1 TO same_role_1;
 GRANT USAGE ON DOMAIN same_domain_1 TO same_role_3;

--- a/test/to-domain.sql
+++ b/test/to-domain.sql
@@ -15,8 +15,6 @@ CREATE DOMAIN same_domain_3 AS text;
 
 COMMENT ON DOMAIN same_domain_2 IS 'this is comment for same_domain_2';
 
-COMMENT ON DOMAIN same_domain_3 IS 'this is comment for same_domain_3 with ''';
-
 GRANT USAGE ON DOMAIN to_domain_1 TO same_role_1, same_role_2, same_role_3;
 GRANT ALL PRIVILEGES ON DOMAIN same_domain_1 TO same_role_1;
 GRANT USAGE ON DOMAIN same_domain_1 TO same_role_3;

--- a/test/to-enum-type.sql
+++ b/test/to-enum-type.sql
@@ -1,0 +1,7 @@
+CREATE TYPE public.feature_type AS ENUM (
+        'val ''01''',
+        'val ''02''',
+        'val ''03''',
+        'val ''04''',
+        'val ''05'''
+);

--- a/test/to-function.sql
+++ b/test/to-function.sql
@@ -37,6 +37,9 @@ SET work_mem TO '100MB';
 
 COMMENT ON FUNCTION same_function_2(integer, integer) IS 'this is comment for same_function_2';
 
+COMMENT ON FUNCTION same_function_3(integer, integer) IS 'this is comment for same_function_3 with ''';
+
+
 GRANT EXECUTE ON FUNCTION to_function_1(integer, integer) TO same_role_1, same_role_2, same_role_3;
 GRANT ALL PRIVILEGES ON FUNCTION same_function_1(integer, integer) TO same_role_1;
 GRANT EXECUTE ON FUNCTION same_function_1(integer, integer) TO same_role_3;

--- a/test/to-function.sql
+++ b/test/to-function.sql
@@ -37,9 +37,6 @@ SET work_mem TO '100MB';
 
 COMMENT ON FUNCTION same_function_2(integer, integer) IS 'this is comment for same_function_2';
 
-COMMENT ON FUNCTION same_function_3(integer, integer) IS 'this is comment for same_function_3 with ''';
-
-
 GRANT EXECUTE ON FUNCTION to_function_1(integer, integer) TO same_role_1, same_role_2, same_role_3;
 GRANT ALL PRIVILEGES ON FUNCTION same_function_1(integer, integer) TO same_role_1;
 GRANT EXECUTE ON FUNCTION same_function_1(integer, integer) TO same_role_3;

--- a/test/to-sequence.sql
+++ b/test/to-sequence.sql
@@ -10,6 +10,8 @@ CREATE SEQUENCE same_sequence_1;
 
 COMMENT ON SEQUENCE to_sequence_2 IS 'this is comment for to_sequence_2';
 
+COMMENT ON SEQUENCE to_sequence_3 IS 'this is comment for to_sequence_3 with ''';
+
 GRANT USAGE ON SEQUENCE to_sequence_1 TO same_role_1, same_role_2, same_role_3;
 GRANT ALL PRIVILEGES ON SEQUENCE same_sequence_1 TO same_role_1;
 GRANT SELECT, USAGE ON SEQUENCE same_sequence_1 TO same_role_3;

--- a/test/to-sequence.sql
+++ b/test/to-sequence.sql
@@ -10,8 +10,6 @@ CREATE SEQUENCE same_sequence_1;
 
 COMMENT ON SEQUENCE to_sequence_2 IS 'this is comment for to_sequence_2';
 
-COMMENT ON SEQUENCE to_sequence_3 IS 'this is comment for to_sequence_3 with ''';
-
 GRANT USAGE ON SEQUENCE to_sequence_1 TO same_role_1, same_role_2, same_role_3;
 GRANT ALL PRIVILEGES ON SEQUENCE same_sequence_1 TO same_role_1;
 GRANT SELECT, USAGE ON SEQUENCE same_sequence_1 TO same_role_3;

--- a/test/to-statistics.sql
+++ b/test/to-statistics.sql
@@ -1,7 +1,8 @@
 CREATE TABLE statistics_table_1 (
 	a integer,
 	b integer,
-	c integer
+	c integer,
+	d integer
 );
 
 CREATE STATISTICS same_statistics_1 (dependencies) ON a, b FROM statistics_table_1;
@@ -10,3 +11,8 @@ CREATE STATISTICS to_statistics_1 (dependencies) ON b, c FROM statistics_table_1
 
 COMMENT ON STATISTICS same_statistics_1 IS NULL;
 COMMENT ON STATISTICS to_statistics_1 IS 'this is a statistics comment';
+
+CREATE STATISTICS to_statistics_2 (dependencies) ON a, d FROM statistics_table_1;
+
+COMMENT ON STATISTICS same_statistics_1 IS NULL;
+COMMENT ON STATISTICS to_statistics_1 IS 'this is a statistics comment with ''';

--- a/test/to-statistics.sql
+++ b/test/to-statistics.sql
@@ -1,8 +1,7 @@
 CREATE TABLE statistics_table_1 (
 	a integer,
 	b integer,
-	c integer,
-	d integer
+	c integer
 );
 
 CREATE STATISTICS same_statistics_1 (dependencies) ON a, b FROM statistics_table_1;
@@ -11,8 +10,3 @@ CREATE STATISTICS to_statistics_1 (dependencies) ON b, c FROM statistics_table_1
 
 COMMENT ON STATISTICS same_statistics_1 IS NULL;
 COMMENT ON STATISTICS to_statistics_1 IS 'this is a statistics comment';
-
-CREATE STATISTICS to_statistics_2 (dependencies) ON a, d FROM statistics_table_1;
-
-COMMENT ON STATISTICS same_statistics_1 IS NULL;
-COMMENT ON STATISTICS to_statistics_1 IS 'this is a statistics comment with ''';

--- a/test/to-table.sql
+++ b/test/to-table.sql
@@ -83,18 +83,6 @@ CREATE TABLE to_table_4 OF same_type_1;
 -- empty table
 CREATE TABLE to_table_5 ();
 
--- table comment with escaped single quote
-CREATE TABLE same_table_6 (
-	a integer not null,
-	b text not null,
-	c varchar(40),
-	d double precision,
-	PRIMARY KEY(a)
-);
-
-COMMENT ON TABLE same_table_6 IS 'this is comment with '' for table same_table_6 modified';
-COMMENT ON COLUMN same_table_6.b IS 'this is comment with '' for column same_table_6.b modified';
-
 -- reloptions
 ALTER TABLE same_table_1 SET (autovacuum_enabled = off, autovacuum_vacuum_cost_delay = 13);
 ALTER TABLE same_table_2 SET (autovacuum_vacuum_scale_factor = 0.44, autovacuum_analyze_scale_factor = 0.22);

--- a/test/to-table.sql
+++ b/test/to-table.sql
@@ -83,6 +83,18 @@ CREATE TABLE to_table_4 OF same_type_1;
 -- empty table
 CREATE TABLE to_table_5 ();
 
+-- table comment with escaped single quote
+CREATE TABLE same_table_6 (
+	a integer not null,
+	b text not null,
+	c varchar(40),
+	d double precision,
+	PRIMARY KEY(a)
+);
+
+COMMENT ON TABLE same_table_6 IS 'this is comment with '' for table same_table_6 modified';
+COMMENT ON COLUMN same_table_6.b IS 'this is comment with '' for column same_table_6.b modified';
+
 -- reloptions
 ALTER TABLE same_table_1 SET (autovacuum_enabled = off, autovacuum_vacuum_cost_delay = 13);
 ALTER TABLE same_table_2 SET (autovacuum_vacuum_scale_factor = 0.44, autovacuum_analyze_scale_factor = 0.22);


### PR DESCRIPTION
If comments were containing escaped single quote then script generated by `pgquarrel` was broken. Simple fix to use dollar-quotes fixes the problem.