### PR TITLE
Add support for sslmode option for postgres params in cfg and cli.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -97,6 +97,7 @@ typedef struct QuarrelDatabaseOptions
 	char			*username;
 	char			*password;
 	char			*dbname;
+	char			*sslmode;
 	bool			istarget;
 	bool			promptpassword;
 } QuarrelDatabaseOptions;


### PR DESCRIPTION
config file
```
[target]
host = localhost
port = 5432
dbname = users
user = postgres
sslmode = require
```

CLI option - `pgquarrel -c my.cfg --source-sslmode=require`

more on sslmode - https://www.postgresql.org/docs/9.1/libpq-connect.html