### PR TITLE
Link project specific library statically

### DIFF
--- a/mini/CMakeLists.txt
+++ b/mini/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(mini SHARED
+add_library(mini STATIC
 	mini-file.c
 	mini-file.h
 	mini-parser.c


### PR DESCRIPTION
_Apologize upfront if this is not the right way to do: I've no real experience with C / cmake_

This is inspired by the problem I hit with https://github.com/eulerto/pgquarrel/issues/87

I could only "fix" it using LD_PRELOAD but I thought what if we can just link the (internal) library statically, then this issue would be gone.

I tested this only on Linux and it worked for me.

Upon installation it still installs `libmini.a` though, not sure if this is ok?
```sh
# installation directory
$ cd pgquarrel ; find
.
./lib
./lib/libmini.a
./bin
./bin/pgquarrel
```