### PR TITLE
Support correct R_PATH linking on MacOS

### DIFF
--- a/mini/CMakeLists.txt
+++ b/mini/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(APPLE)
+	set( CMAKE_MACOSX_RPATH 1 )
+endif()
+
 add_library(mini SHARED
 	mini-file.c
 	mini-file.h


### PR DESCRIPTION
I successfully installed pgquarrel on my mac, but when I tried to run it I got the macos version of issue #87. This PR will fix it for MacOS.

This PR will also fix the following warning on MacOS:
```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   mini

This warning is for project developers.  Use -Wno-dev to suppress it.
```

For some reason the INSTALL_RPATH property doesn't just work on macos. So we have to set the CMAKE_MACOSX_RPATH property for rpaths to work.

This change was inspired by PR #88