### PR TITLE
Fix reference to polnamespace (segfault)

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -33,7 +33,7 @@ getPolicies(PGconn *c, int *n)
 
 	logNoise("policy: server version: %d", PQserverVersion(c));
 
-	query = psprintf("SELECT p.oid, p.polname, p.polrelid, n.nspname AS polnamespace, c.relname AS poltabname, p.polcmd, p.polpermissive, CASE WHEN p.polroles = '{0}' THEN NULL ELSE pg_catalog.array_to_string(ARRAY(SELECT pg_catalog.quote_ident(rolname) from pg_catalog.pg_roles WHERE oid = ANY(p.polroles)), ', ') END AS polroles, pg_catalog.pg_get_expr(p.polqual, p.polrelid) AS polqual, pg_catalog.pg_get_expr(p.polwithcheck, p.polrelid) AS polwithcheck FROM pg_policy p INNER JOIN pg_class c ON (p.polrelid = c.oid) INNER JOIN pg_namespace n ON (c.relnamespace = n.oid) WHERE TRUE %s%s ORDER BY p.polname", include_schema_str, exclude_schema_str);
+	query = psprintf("SELECT p.oid, p.polname, p.polrelid, n.nspname AS polnamespace, c.relname AS poltabname, p.polcmd, p.polpermissive, CASE WHEN p.polroles = '{0}' THEN NULL ELSE pg_catalog.array_to_string(ARRAY(SELECT pg_catalog.quote_ident(rolname) from pg_catalog.pg_roles WHERE oid = ANY(p.polroles)), ', ') END AS polroles, pg_catalog.pg_get_expr(p.polqual, p.polrelid) AS polqual, pg_catalog.pg_get_expr(p.polwithcheck, p.polrelid) AS polwithcheck, d.description AS description FROM pg_policy p INNER JOIN pg_class c ON (p.polrelid = c.oid) INNER JOIN pg_namespace n ON (c.relnamespace = n.oid) LEFT JOIN pg_description d ON (p.oid = d.objoid) WHERE TRUE %s%s ORDER BY p.polname", include_schema_str, exclude_schema_str);
 
 	res = PQexec(c, query);
 

--- a/src/policy.c
+++ b/src/policy.c
@@ -65,7 +65,7 @@ getPolicies(PGconn *c, int *n)
 		p[i].table.oid = strtoul(PQgetvalue(res, i, PQfnumber(res, "polrelid")), NULL,
 								 10);
 		p[i].table.schemaname = strdup(PQgetvalue(res, i, PQfnumber(res,
-									   "polnspname")));
+									   "polnamespace")));
 		p[i].table.objectname = strdup(PQgetvalue(res, i, PQfnumber(res,
 									   "poltabname")));
 		p[i].cmd = PQgetvalue(res, i, PQfnumber(res, "polcmd"))[0];


### PR DESCRIPTION
It looks like the query returns the namespace name as `polnamespace`, but the code incorrectly asks for `polnspname`, causing a segfault when `policy = true`. This change fixes the issue for me locally.