### PR TITLE
GENERATED AS IDENTITY support

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -142,6 +142,7 @@ typedef struct PQLAttribute
 	int			attstattarget;
 	char		*attstorage;
 	bool		defstorage;
+	char        attidentity;
 	char		*attoptions;
 	char		*attfdwoptions;
 	char		*comment;

--- a/src/sequence.c
+++ b/src/sequence.c
@@ -38,7 +38,7 @@ getSequences(PGconn *c, int *n)
 
 	if (PQserverVersion(c) >= 90100)	/* extension support */
 	{
-		query = psprintf("SELECT c.oid, n.nspname, c.relname, obj_description(c.oid, 'pg_class') AS description, pg_get_userbyid(c.relowner) AS relowner, relacl FROM pg_class c INNER JOIN pg_namespace n ON (c.relnamespace = n.oid) WHERE relkind = 'S' AND nspname !~ '^pg_' AND nspname <> 'information_schema' %s%s AND NOT EXISTS(SELECT 1 FROM pg_depend d WHERE c.oid = d.objid AND d.deptype = 'e') ORDER BY nspname, relname", include_schema_str, exclude_schema_str);
+		query = psprintf("SELECT c.oid, n.nspname, c.relname, obj_description(c.oid, 'pg_class') AS description, pg_get_userbyid(c.relowner) AS relowner, relacl FROM pg_class c INNER JOIN pg_namespace n ON (c.relnamespace = n.oid) WHERE relkind = 'S' AND nspname !~ '^pg_' AND nspname <> 'information_schema' %s%s AND NOT EXISTS(SELECT 1 FROM pg_depend d WHERE c.oid = d.objid AND (d.deptype = 'e' OR d.deptype = 'i')) ORDER BY nspname, relname", include_schema_str, exclude_schema_str);
 	}
 	else
 	{

--- a/test/to-table.sql
+++ b/test/to-table.sql
@@ -78,6 +78,12 @@ CREATE TABLE same_table_5 (
 
 CREATE TABLE same_table_6 OF same_type_1;
 
+-- GENERATED AS IDENTITY
+CREATE TABLE same_table_8 (
+	a integer generated always as identity primary key,
+	b text
+);
+
 CREATE TABLE to_table_4 OF same_type_1;
 
 -- empty table


### PR DESCRIPTION
This adds support for `GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY` (introduced in PG 10).

I'm not sure I got all the queries right (particularly around the sequence one) but in my local tests this appears to work as expected. Please let me know if there is any feedback I can apply since I'm relatively new to introspecting PostgreSQL in this way!

Note that there are edge cases that are broken: you can't go from `SERIAL` to `IDENTITY` and vice versa. The issue with this is that the `GENERATED ... IDENTITY` manages its sequence internally and we quarrel sequences first so you get some bad behaviors. In general, [converting between the two seems like a problem](https://www.2ndquadrant.com/en/blog/postgresql-10-identity-columns/) since maintaining the correct sequence point is a PITA, and I'm not sure if pgquarrel wants to even attempt this, but perhaps an error is more appropriate here or ignoring that change entirely...