### PR TITLE
Remove semi-colon after name on CREATE POLICY

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -160,7 +160,7 @@ dumpCreatePolicy(FILE *output, PQLPolicy *p)
 	}
 
 	fprintf(output, "\n\n");
-	fprintf(output, "CREATE POLICY %s;", p->polname);
+	fprintf(output, "CREATE POLICY %s", p->polname);
 	fprintf(output, " ON %s.%s%s%s", schema, tabname,
 			(!p->permissive ? " AS RESTRICTIVE" : ""), cmd);
 


### PR DESCRIPTION
The semi-colon gives invalid SQL, e.g.

```
CREATE POLICY user_all_view; ON public.persons FOR SELECT USING (true);
```